### PR TITLE
Remove k8s-test dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ jobs:
         # Wait for stuff to become ready
         - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
-         # Get SPIRE master (we need it to build k8s-test tool)
-        - git clone https://github.com/spiffe/spire.git
-
       script:
         # Run systems tests
         - examples/k8s/test-all.sh

--- a/examples/k8s/postgres/kustomization.yaml
+++ b/examples/k8s/postgres/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: spire
+
+resources:
+- spire-database.yaml
+- spire-server.yaml
+- spire-agent.yaml

--- a/examples/k8s/postgres/test.sh
+++ b/examples/k8s/postgres/test.sh
@@ -1,26 +1,67 @@
 #!/bin/bash
 
-set -e
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cleanup() {
-	# cleans the test environment (deletes the spire namespace)
-	k8s-test clean
+bold=$(tput bold) || true
+norm=$(tput sgr0) || true
+red=$(tput setaf 1) || true
+green=$(tput setaf 2) || true
+yellow=$(tput setaf 3) || true
+
+fail() {
+	echo "${red}$*${norm}."
+	exit 1
 }
+
+delete-ns() {
+	echo "${bold}Cleaning up...${norm}"
+    kubectl delete --ignore-not-found namespace spire > /dev/null
+}
+
+cleanup() {
+    if [ -z "${GOOD}" ]; then
+        echo "${yellow}Dumping statefulset/spire-database logs...${norm}"
+        kubectl -nspire logs statefulset/spire-database --all-containers
+        echo "${yellow}Dumping deployment/spire-server logs...${norm}"
+        kubectl -nspire logs deployment/spire-server --all-containers
+        echo "${yellow}Dumping daemonset/spire-agent logs...${norm}"
+        kubectl -nspire logs daemonset/spire-agent --all-containers
+    fi
+    delete-ns
+    if [ -n "${GOOD}" ]; then
+        echo "${green}Success.${norm}"
+    else
+        echo "${red}Failed.${norm}"
+    fi
+}
+
 trap cleanup EXIT
 
-# initialize the test environment (creates a clean spire namespace)
-k8s-test init
+echo "${bold}Preparing environment...${norm}"
+delete-ns
+kubectl create namespace spire
 
-# apply the postgres configuration (and waits until it is ready)
-k8s-test apply --no-local "${DIR}"/spire-database.yaml
+echo "${bold}Applying configuration...${norm}"
+kubectl apply -k "${DIR}"
 
-# apply the server configuration (and waits until it is ready)
-k8s-test apply --no-local "${DIR}"/spire-server.yaml
+LOGLINE="Node attestation request .* completed"
+for ((i=0;i<120;i++)); do
+    if ! kubectl -nspire rollout status deployment/spire-server; then
+        sleep 1
+        continue
+    fi
+    if ! kubectl -nspire rollout status daemonset/spire-agent; then
+        sleep 1
+        continue
+    fi
+    if ! kubectl -nspire logs deployment/spire-server -c spire-server | grep -e "$LOGLINE" ; then
+        sleep 1
+        continue
+    fi
+    echo "${bold}Node attested.${norm}"
+    GOOD=1
+    exit 0
+done
 
-# apply the agent configuration (and waits until it is ready)
-k8s-test apply --no-local "${DIR}"/spire-agent.yaml
-
-# wait for a node to attest
-k8s-test wait node-attestation deployment/spire-server
+echo "${red}Timed out waiting for node to attest.${norm}"
+exit 1

--- a/examples/k8s/simple_psat/kustomization.yaml
+++ b/examples/k8s/simple_psat/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: spire
+
+resources:
+- spire-server.yaml
+- spire-agent.yaml

--- a/examples/k8s/simple_psat/test.sh
+++ b/examples/k8s/simple_psat/test.sh
@@ -1,23 +1,65 @@
 #!/bin/bash
 
-set -e
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cleanup() {
-	# cleans the test environment (deletes the spire namespace)
-	k8s-test clean
+bold=$(tput bold) || true
+norm=$(tput sgr0) || true
+red=$(tput setaf 1) || true
+green=$(tput setaf 2) || true
+yellow=$(tput setaf 3) || true
+
+fail() {
+	echo "${red}$*${norm}."
+	exit 1
 }
+
+delete-ns() {
+	echo "${bold}Cleaning up...${norm}"
+    kubectl delete --ignore-not-found namespace spire > /dev/null
+}
+
+cleanup() {
+    if [ -z "${GOOD}" ]; then
+        echo "${yellow}Dumping statefulset/spire-server logs...${norm}"
+        kubectl -nspire logs statefulset/spire-server --all-containers
+        echo "${yellow}Dumping daemonset/spire-agent logs...${norm}"
+        kubectl -nspire logs daemonset/spire-agent --all-containers
+    fi
+    delete-ns
+    if [ -n "${GOOD}" ]; then
+        echo "${green}Success.${norm}"
+    else
+        echo "${red}Failed.${norm}"
+    fi
+}
+
 trap cleanup EXIT
 
-# initialize the test environment (creates a clean spire namespace)
-k8s-test init
+echo "${bold}Preparing environment...${norm}"
+delete-ns
+kubectl create namespace spire
 
-# apply the server configuration (and waits until it is ready)
-k8s-test apply --no-local "${DIR}"/spire-server.yaml
+echo "${bold}Applying configuration...${norm}"
+kubectl apply -k "${DIR}"
 
-# apply the agent configuration (and waits until it is ready)
-k8s-test apply --no-local "${DIR}"/spire-agent.yaml
+LOGLINE="Node attestation request .* completed"
+for ((i=0;i<120;i++)); do
+    if ! kubectl -nspire rollout status statefulset/spire-server; then
+        sleep 1
+        continue
+    fi
+    if ! kubectl -nspire rollout status daemonset/spire-agent; then
+        sleep 1
+        continue
+    fi
+    if ! kubectl -nspire logs statefulset/spire-server -c spire-server | grep -e "$LOGLINE" ; then
+        sleep 1
+        continue
+    fi
+    echo "${bold}Node attested.${norm}"
+    GOOD=1
+    exit 0
+done
 
-# wait for a node to attest
-k8s-test wait node-attestation statefulset/spire-server
+echo "${red}Timed out waiting for node to attest.${norm}"
+exit 1

--- a/examples/k8s/simple_sat/kustomization.yaml
+++ b/examples/k8s/simple_sat/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: spire
+
+resources:
+- spire-server.yaml
+- spire-agent.yaml

--- a/examples/k8s/simple_sat/test.sh
+++ b/examples/k8s/simple_sat/test.sh
@@ -44,7 +44,7 @@ kubectl apply -k "${DIR}"
 
 LOGLINE="Node attestation request .* completed"
 for ((i=0;i<120;i++)); do
-    if ! kubectl -nspire rollout status deployment/spire-server; then
+    if ! kubectl -nspire rollout status statefulset/spire-server; then
         sleep 1
         continue
     fi
@@ -52,7 +52,7 @@ for ((i=0;i<120;i++)); do
         sleep 1
         continue
     fi
-    if ! kubectl -nspire logs deployment/spire-server -c spire-server | grep -e "$LOGLINE" ; then
+    if ! kubectl -nspire logs statefulset/spire-server -c spire-server | grep -e "$LOGLINE" ; then
         sleep 1
         continue
     fi

--- a/examples/k8s/test-all.sh
+++ b/examples/k8s/test-all.sh
@@ -18,19 +18,12 @@ command -v kubectl > /dev/null || fail "kubectl is required."
 echo "${bold}Checking minikube status...${norm}"
 minikube status || fail "minikube isn't running"
 
-echo "${bold}Installing k8s-test...${norm}"
-( cd "${DIR}"/../../spire/tools/k8s-test && GO111MODULE=on go install ) || fail "unable to build k8s-test"
-
-# add GOPATH/bin to the PATH
-PATH="$(go env GOPATH)"/bin:$PATH
-export PATH
-
 echo "${bold}Running all tests...${norm}"
 for testdir in "${DIR}"/*; do
 	if [[ -x "${testdir}/test.sh" ]]; then
 		testname=$(basename "$testdir")
 		echo "${bold}Running \"$testname\" test...${norm}"
-		if LOGPREFIX=$testname "${testdir}/test.sh"; then
+		if ${testdir}/test.sh; then
 			echo "${green}\"$testname\" test succeeded${norm}"
 		else
 			echo "${red}\"$testname\" test failed${norm}"


### PR DESCRIPTION
This PR removes the k8s-test dependency from the SPIRE repo. It changes each test to apply configuration using kustomize, do some simple checks to ensure the server and agent rollout clean, and then perform a simple grep check for successful node attestation. On failure, it dumps all of the container logs for inspection.