### PR TITLE
Added required config props to start minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         # Download latest minikube
         - curl -s -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
         # Start up minikube
-        - sudo minikube start --vm-driver=none --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub --extra-config=apiserver.service-account-issuer=api --extra-config=apiserver.service-account-api-audiences=api,spire-server --extra-config=apiserver.authorization-mode=RBAC
+        - sudo minikube start --vm-driver=none --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub --extra-config=apiserver.service-account-issuer=api --extra-config=apiserver.service-account-api-audiences=api,spire-server --extra-config=apiserver.authorization-mode=Node,RBAC
 
         # Make sure kubectl configuration is up to date
         - sudo chown -R $USER.$USER ~/.kube


### PR DESCRIPTION
As stated here https://github.com/kubernetes/minikube/issues/6061#issuecomment-566190474, to start minikube we need to add `Node` to the extra config authorization mode: `--extra-config=apiserver.authorization-mode=Node,RBAC`
