### PR TITLE
Updates k7e examples to use SPIRE 0.10.0

### DIFF
--- a/examples/k8s/k7e/base_minikube_sat/config/spire-agent.conf
+++ b/examples/k8s/k7e/base_minikube_sat/config/spire-agent.conf
@@ -22,7 +22,10 @@ plugins {
 
   WorkloadAttestor "k8s" {
     plugin_data {
-      kubelet_read_only_port = "10255"
+      # Defaults to the secure kubelet port by default.
+      # Minikube does not have a cert in the cluster CA bundle that
+      # can authenticate the kubelet cert, so skip validation.
+      skip_kubelet_verification = true
     }
   }
 

--- a/examples/k8s/k7e/base_minikube_sat/config/spire-server.conf
+++ b/examples/k8s/k7e/base_minikube_sat/config/spire-server.conf
@@ -4,7 +4,7 @@ server {
   trust_domain = "example.org"
   data_dir = "/run/spire/data"
   log_level = "DEBUG"
-  svid_ttl = "1h"
+  default_svid_ttl = "1h"
   ca_subject = {
     Country = ["US"],
     Organization = ["SPIFFE"],

--- a/examples/k8s/k7e/base_minikube_sat/spire-agent/spire-agent-deployment.yaml
+++ b/examples/k8s/k7e/base_minikube_sat/spire-agent/spire-agent-deployment.yaml
@@ -28,8 +28,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:429286051c1e0d729be2bec8d7ee26204494cf7a
-          #TODO: use image: gcr.io/spiffe-io/spire-agent:0.10.0
+          image: gcr.io/spiffe-io/spire-agent:0.10.0
           imagePullPolicy: Always
           args: ["-config", "/run/spire/config/spire-agent.conf"]
           volumeMounts:

--- a/examples/k8s/k7e/base_minikube_sat/spire-agent/spire-agent-deployment.yaml
+++ b/examples/k8s/k7e/base_minikube_sat/spire-agent/spire-agent-deployment.yaml
@@ -28,7 +28,8 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.9.0
+          image: gcr.io/spiffe-io/spire-agent:429286051c1e0d729be2bec8d7ee26204494cf7a
+          #TODO: use image: gcr.io/spiffe-io/spire-agent:0.10.0
           imagePullPolicy: Always
           args: ["-config", "/run/spire/config/spire-agent.conf"]
           volumeMounts:

--- a/examples/k8s/k7e/base_minikube_sat/spire-server/spire-server-deployment.yaml
+++ b/examples/k8s/k7e/base_minikube_sat/spire-server/spire-server-deployment.yaml
@@ -20,8 +20,7 @@ spec:
       serviceAccountName: spire-server
       containers:
       - name: spire-server
-        image: gcr.io/spiffe-io/spire-server:429286051c1e0d729be2bec8d7ee26204494cf7a
-        #TODO: use image: gcr.io/spiffe-io/spire-server:0.10.0
+        image: gcr.io/spiffe-io/spire-server:0.10.0
         imagePullPolicy: Always
         args: ["-config", "/run/spire/config/spire-server.conf"]
         ports:

--- a/examples/k8s/k7e/base_minikube_sat/spire-server/spire-server-deployment.yaml
+++ b/examples/k8s/k7e/base_minikube_sat/spire-server/spire-server-deployment.yaml
@@ -20,7 +20,8 @@ spec:
       serviceAccountName: spire-server
       containers:
       - name: spire-server
-        image: gcr.io/spiffe-io/spire-server:0.9.0
+        image: gcr.io/spiffe-io/spire-server:429286051c1e0d729be2bec8d7ee26204494cf7a
+        #TODO: use image: gcr.io/spiffe-io/spire-server:0.10.0
         imagePullPolicy: Always
         args: ["-config", "/run/spire/config/spire-server.conf"]
         ports:

--- a/examples/k8s/k7e/community_day_2019_may/client-deployment.yaml
+++ b/examples/k8s/k7e/community_day_2019_may/client-deployment.yaml
@@ -16,8 +16,7 @@ spec:
     spec:
       containers:
         - name: client
-          image: gcr.io/spiffe-io/spire-agent:429286051c1e0d729be2bec8d7ee26204494cf7a
-          #TODO: use image: gcr.io/spiffe-io/spire-agent:0.10.0
+          image: gcr.io/spiffe-io/spire-agent:0.10.0
           imagePullPolicy: Always
           command: ["/bin/sleep", "1d"]
           volumeMounts:

--- a/examples/k8s/k7e/community_day_2019_may/client-deployment.yaml
+++ b/examples/k8s/k7e/community_day_2019_may/client-deployment.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       containers:
         - name: client
-          image: gcr.io/spiffe-io/spire-agent:0.9.0
+          image: gcr.io/spiffe-io/spire-agent:429286051c1e0d729be2bec8d7ee26204494cf7a
+          #TODO: use image: gcr.io/spiffe-io/spire-agent:0.10.0
           imagePullPolicy: Always
           command: ["/bin/sleep", "1d"]
           volumeMounts:


### PR DESCRIPTION
This PR updates the k7e examples to use the version 0.10.0 RC of SPIRE

Signed-off-by: Maximiliano Churichi <mchurichi@gmail.com>