### PR TITLE
replaced verify_subject_alt_name by match_subject_alt_names

### DIFF
--- a/examples/envoy/docker/echo/conf/envoy.yaml
+++ b/examples/envoy/docker/echo/conf/envoy.yaml
@@ -49,8 +49,8 @@ static_resources:
           combined_validation_context:
             # validate the SPIFFE ID of incoming clients (optionally)
             default_validation_context:
-              verify_subject_alt_name:
-                - "spiffe://domain.test/web-server"
+              match_subject_alt_names:
+                - exact: "spiffe://domain.test/web-server"
             # obtain the trust bundle from SDS
             validation_context_sds_secret_config:
               name: "spiffe://domain.test"

--- a/examples/envoy/docker/web/conf/envoy.yaml
+++ b/examples/envoy/docker/web/conf/envoy.yaml
@@ -92,8 +92,8 @@ static_resources:
         combined_validation_context:
           # validate the SPIFFE ID of the server (recommended)
           default_validation_context:
-            verify_subject_alt_name:
-              - "spiffe://domain.test/echo-server"
+            match_subject_alt_names:
+              - exact: "spiffe://domain.test/echo-server"
           validation_context_sds_secret_config:
             name: "spiffe://domain.test"
             sds_config:
@@ -118,8 +118,8 @@ static_resources:
         combined_validation_context:
           # validate the SPIFFE ID of the server (recommended)
           default_validation_context:
-            verify_subject_alt_name:
-              - "spiffe://domain.test/echo-server"
+            match_subject_alt_names:
+              - exact: "spiffe://domain.test/echo-server"
           validation_context_sds_secret_config:
             name: "spiffe://domain.test"
             sds_config:


### PR DESCRIPTION
Replacement of `verify_subject_alt_name` (deprecated in new versions of Envoy) by `match_subject_alt_names`

Signed-off-by: Andres Gomez Coronel <andresgomezcoronel@gmail.com>