### PR TITLE
Update envoy example to use spire 0.11.0 and envoy 1.14.4

### DIFF
--- a/examples/envoy/README.md
+++ b/examples/envoy/README.md
@@ -1,8 +1,8 @@
-# Envoy 1.14.1 SDS Example with SPIRE 0.10.0
+# Envoy 1.14.1 SDS Example with SPIRE 0.11.0
 
 ## Requirements
 
-- Go 1.12
+- Go 1.14
 - docker-compose
 
 ## Build

--- a/examples/envoy/docker/echo/Dockerfile
+++ b/examples/envoy/docker/echo/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcr.io/spiffe-io/spire-agent:0.10.0 as spire
+FROM gcr.io/spiffe-io/spire-agent:0.11.0 as spire
 
-FROM envoyproxy/envoy-alpine:v1.14.1
+FROM envoyproxy/envoy-alpine:v1.14.4
 RUN mkdir -p /opt/spire/conf/agent
 RUN mkdir -p /opt/spire/data/agent
 COPY --from=spire /opt/spire/bin/spire-agent /opt/spire/bin/spire-agent

--- a/examples/envoy/docker/echo/conf/spire-agent.conf
+++ b/examples/envoy/docker/echo/conf/spire-agent.conf
@@ -7,7 +7,6 @@ agent {
 	socket_path ="/tmp/agent.sock"
 	trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
 	trust_domain = "domain.test"
-	enable_sds = true
 }
 
 plugins {

--- a/examples/envoy/docker/spire-server/Dockerfile
+++ b/examples/envoy/docker/spire-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/spiffe-io/spire-server:0.10.0
+FROM gcr.io/spiffe-io/spire-server:0.11.0
 
 # Override spire configurations
 COPY conf/spire-server.conf /opt/spire/conf/server/server.conf

--- a/examples/envoy/docker/spire-server/conf/spire-server.conf
+++ b/examples/envoy/docker/spire-server/conf/spire-server.conf
@@ -4,7 +4,6 @@ server {
 	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
-	plugin_dir = "/opt/spire/conf/server/plugin"
 	log_level = "DEBUG"
 	log_file = "/opt/spire/server.log"
 	default_svid_ttl = "1h"

--- a/examples/envoy/docker/web/Dockerfile
+++ b/examples/envoy/docker/web/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcr.io/spiffe-io/spire-agent:0.10.0 as spire
+FROM gcr.io/spiffe-io/spire-agent:0.11.0 as spire
 
-FROM envoyproxy/envoy-alpine:v1.14.1
+FROM envoyproxy/envoy-alpine:v1.14.4
 RUN mkdir -p /opt/spire/conf/agent
 RUN mkdir -p /opt/spire/data/agent
 COPY --from=spire /opt/spire/bin/spire-agent /opt/spire/bin/spire-agent

--- a/examples/envoy/docker/web/conf/spire-agent.conf
+++ b/examples/envoy/docker/web/conf/spire-agent.conf
@@ -7,7 +7,6 @@ agent {
 	socket_path ="/tmp/agent.sock"
 	trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
 	trust_domain = "domain.test"
-	enable_sds = true
 }
 
 plugins {

--- a/examples/envoy/src/echo-server/go.mod
+++ b/examples/envoy/src/echo-server/go.mod
@@ -1,3 +1,3 @@
 module echo-server
 
-go 1.12
+go 1.14

--- a/examples/envoy/src/web-server/go.mod
+++ b/examples/envoy/src/web-server/go.mod
@@ -2,4 +2,4 @@ module web-server
 
 require github.com/go-chi/chi v3.3.3+incompatible
 
-go 1.12
+go 1.14


### PR DESCRIPTION
Upgrade envoy example to use 0.11.0 release and envoy 1.14.4

Signed-off-by: Marcos Yacob <marcos.yacob@hpe.com>