### PR TITLE
Fix minikube start usage for VM driver

### DIFF
--- a/examples/k8s/simple_psat/README.md
+++ b/examples/k8s/simple_psat/README.md
@@ -22,7 +22,7 @@ The following flags must be passed to the Kubernetes API server to properly run 
 
 If you are using minikube, make sure it is started as follows:
 ```
-minikube start  --vm-driver=virtualbox \
+minikube start  --driver=virtualbox \
                 --extra-config=apiserver.authorization-mode=Node,RBAC \
                 --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key \
                 --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub \


### PR DESCRIPTION
The `--vm-driver` argument has been deprecated in favor of the `--driver` argument. Updating the k8s_psat example documentation to reference the latest argument name.