### PR TITLE
Minor fixes to enable deployment of k8s-workload-registrar

### DIFF
--- a/examples/k8s/advanced/0-check-requirements.sh
+++ b/examples/k8s/advanced/0-check-requirements.sh
@@ -2,4 +2,4 @@
 which kind || (echo "kind not found"; exit 1)
 which helm || (echo "helm not found"; exit 1)
 which docker || (echo "docker not found"; exit 1)
-(helm version | grep "Version:\"v3.0") || (echo "Helm is not version 3"; exit 1)
+(helm version | grep "Version:\"v3.") || (echo "Helm is not version 3"; exit 1)

--- a/examples/k8s/advanced/1-create-cluster.sh
+++ b/examples/k8s/advanced/1-create-cluster.sh
@@ -11,10 +11,13 @@ if [ "${running}" != 'true' ]; then
     registry:2
 fi
 
-# Create the cluster. 
-# The containerdConfigPatches line is useful to configure access to the local registry. 
+# Create the cluster.
+# The containerdConfigPatches line is useful to configure access to the local registry.
 # The ClusterConfiguration options are needed for nodes to access projected service
 # account tokens.
+# The example uses serviceAccountToken that is by default enabled in K8s 1.20
+# To simplify the deployment, select a node image with K8s 1.20 or higher.
+# The complete list of Kind images: https://github.com/kubernetes-sigs/kind/releases
 cat <<EOF | kind create cluster --name spire-example -v 5 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -24,6 +27,7 @@ containerdConfigPatches:
     endpoint = ["http://${reg_name}:${reg_port}"]
 nodes:
 - role: control-plane
+  image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
   kubeadmConfigPatches:
   - |
 EOF

--- a/examples/k8s/advanced/3-install-spire.sh
+++ b/examples/k8s/advanced/3-install-spire.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-helm uninstall spire 
+helm uninstall spire 2>/dev/null
 while (kubectl get namespaces -o NAME | grep spire); do echo "Waiting for helm uninstall to complete"; sleep 1; done
 helm install spire spire-chart

--- a/examples/k8s/advanced/spire-chart/templates/server-configmap.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/server-configmap.tpl
@@ -36,7 +36,7 @@ data:
         plugin_data {
             clusters = {
                 "{{ .Values.clustername }}" = {
-                    service_account_whitelist = ["production:spire-agent"]
+                    service_account_whitelist = ["spire:spire-agent"]
                 }
             }
         }

--- a/examples/k8s/advanced/spire-chart/templates/server-statefulset.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/server-statefulset.tpl
@@ -49,8 +49,9 @@ spec:
             periodSeconds: 6000
             timeoutSeconds: 3
         - name: k8s-workload-registrar
-          image: k8s-workload-registrar:latest
-          imagePullPolicy: Never
+          #image: k8s-workload-registrar:latest
+          image: gcr.io/spiffe-io/k8s-workload-registrar@sha256:912484f6c0fb40eafb16ba4dd2d0e1b0c9d057c2625b8ece509f5510eaf5b704
+          imagePullPolicy: Always
           args:
             - -config
             - /run/k8s-workload-registrar/config/registrar.conf

--- a/examples/k8s/advanced/spire-chart/templates/spire-roles.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/spire-roles.tpl
@@ -17,7 +17,7 @@ rules:
     verbs: ["get", "watch", "list", "create"]
   - apiGroups: [""]
     resources: ["nodes","pods"]
-    verbs: ["list"]
+    verbs: ["list","get"]
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["spire-bundle"]


### PR DESCRIPTION
A few, very minor adjustments to enable seamless deployment of k8s-workload-registrar helm charts.
The example uses serviceAccountToken that is by default enabled in K8s 1.20, so a specific KIND image is required. 
The example uses namespace 'spire', the ClusterRole rules need to allow getting pod from APIs.