### PR TITLE
Updates Minikube start option to --driver because --vm-driver is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
         # Download latest minikube
         - curl -s -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
         # Start up minikube
-        - sudo minikube start --vm-driver=none --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub --extra-config=apiserver.service-account-issuer=api --extra-config=apiserver.service-account-api-audiences=api,spire-server --extra-config=apiserver.authorization-mode=Node,RBAC
+        - sudo minikube start --driver=none --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub --extra-config=apiserver.service-account-issuer=api --extra-config=apiserver.service-account-api-audiences=api,spire-server --extra-config=apiserver.authorization-mode=Node,RBAC
 
         # Make sure kubectl configuration is up to date
         - sudo chown -R $USER.$USER ~/.kube


### PR DESCRIPTION
The `--vm-driver` argument has been deprecated in favor of the `--driver` argument. Updating `.travis.yml` to reference the latest argument name.
ref: https://minikube.sigs.k8s.io/docs/commands/start/#options
