### PR TITLE
Update Go version to 1.14 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ services:
 
 language: go
 
+go:
+- 1.14.x
+
 cache:
   directories:
     - .cache

--- a/examples/envoy/src/web-server/go.mod
+++ b/examples/envoy/src/web-server/go.mod
@@ -1,5 +1,5 @@
 module web-server
 
-require github.com/go-chi/chi v3.3.3+incompatible
+require github.com/go-chi/chi v4.1.2+incompatible
 
 go 1.14

--- a/examples/envoy/src/web-server/go.sum
+++ b/examples/envoy/src/web-server/go.sum
@@ -1,2 +1,2 @@
-github.com/go-chi/chi v3.3.3+incompatible h1:KHkmBEMNkwKuK4FdQL7N2wOeB9jnIx7jR5wsuSBEFI8=
-github.com/go-chi/chi v3.3.3+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
+github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=


### PR DESCRIPTION
Update go version to solve build error, because older version.

Signed-off-by: Marcos Yacob <marcos.yacob@hpe.com>