### PR TITLE
Use the healthcheck endpoints in the kubernetes manifests

### DIFF
--- a/examples/k8s/advanced/spire-chart/templates/agent-configmap.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/agent-configmap.tpl
@@ -35,3 +35,11 @@ data:
         }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }

--- a/examples/k8s/advanced/spire-chart/templates/agent-daemonset.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/agent-daemonset.tpl
@@ -43,16 +43,19 @@ spec:
             - name: spire-agent-token
               mountPath: /var/run/secrets/tokens
           livenessProbe:
-            exec:
-              command:
-                - /opt/spire/bin/spire-agent
-                - healthcheck
-                - -socketPath
-                - /run/spire/sockets/agent.sock
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: spire-config
           configMap:

--- a/examples/k8s/advanced/spire-chart/templates/server-configmap.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/server-configmap.tpl
@@ -65,3 +65,11 @@ data:
         }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }

--- a/examples/k8s/advanced/spire-chart/templates/server-statefulset.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/server-statefulset.tpl
@@ -40,14 +40,19 @@ spec:
             - name: spire-secret
               mountPath: /run/spire/secret
           livenessProbe:
-            exec:
-              command:
-                - /opt/spire/bin/spire-server
-                - healthcheck
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 6000
             timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
         - name: k8s-workload-registrar
           #image: k8s-workload-registrar:latest
           image: gcr.io/spiffe-io/k8s-workload-registrar@sha256:912484f6c0fb40eafb16ba4dd2d0e1b0c9d057c2625b8ece509f5510eaf5b704

--- a/examples/k8s/eks_sat/spire-agent.yaml
+++ b/examples/k8s/eks_sat/spire-agent.yaml
@@ -73,6 +73,14 @@ data:
           }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
   bootstrap.crt: |
     -----BEGIN CERTIFICATE-----
     MIIBzDCCAVOgAwIBAgIJAJM4DhRH0vmuMAoGCCqGSM49BAMEMB4xCzAJBgNVBAYT
@@ -129,15 +137,17 @@ spec:
               mountPath: /run/spire/sockets
               readOnly: false
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:

--- a/examples/k8s/eks_sat/spire-server.yaml
+++ b/examples/k8s/eks_sat/spire-server.yaml
@@ -109,6 +109,14 @@ data:
         }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
   bootstrap.crt: |
     -----BEGIN CERTIFICATE-----
     MIIBzDCCAVOgAwIBAgIJAJM4DhRH0vmuMAoGCCqGSM49BAMEMB4xCzAJBgNVBAYT
@@ -162,15 +170,17 @@ spec:
               mountPath: /run/spire/data
               readOnly: false
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
-            periodSeconds: 60
+            periodSeconds: 6000
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:

--- a/examples/k8s/k7e/base_minikube_sat/config/spire-agent.conf
+++ b/examples/k8s/k7e/base_minikube_sat/config/spire-agent.conf
@@ -34,3 +34,11 @@ plugins {
       }
   }
 }
+
+health_checks {
+  listener_enabled = true
+  bind_address = "0.0.0.0"
+  bind_port = "8080"
+  live_path = "/live"
+  ready_path = "/ready"
+}

--- a/examples/k8s/k7e/base_minikube_sat/config/spire-server.conf
+++ b/examples/k8s/k7e/base_minikube_sat/config/spire-server.conf
@@ -46,3 +46,11 @@ plugins {
   }
 
 }
+
+health_checks {
+  listener_enabled = true
+  bind_address = "0.0.0.0"
+  bind_port = "8080"
+  live_path = "/live"
+  ready_path = "/ready"
+}

--- a/examples/k8s/k7e/base_minikube_sat/spire-agent/spire-agent-deployment.yaml
+++ b/examples/k8s/k7e/base_minikube_sat/spire-agent/spire-agent-deployment.yaml
@@ -42,15 +42,19 @@ spec:
               mountPath: /run/spire/sockets
               readOnly: false
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - "/opt/spire/bin/spire-agent api fetch -socketPath /run/spire/sockets/agent.sock 2>&1 | grep -vqE 'connection refused|no such file or directory'"
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: spire-config
           configMap:

--- a/examples/k8s/k7e/base_minikube_sat/spire-server/spire-server-deployment.yaml
+++ b/examples/k8s/k7e/base_minikube_sat/spire-server/spire-server-deployment.yaml
@@ -36,12 +36,19 @@ spec:
               mountPath: /run/k8s-certs/sa.pub
               readOnly: true
           livenessProbe:
-            tcpSocket:
-              port: 8081
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: spire-config
           configMap:

--- a/examples/k8s/postgres/spire-agent.yaml
+++ b/examples/k8s/postgres/spire-agent.yaml
@@ -49,6 +49,14 @@ data:
           }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
   bootstrap.crt: |
     -----BEGIN CERTIFICATE-----
     MIIBzDCCAVOgAwIBAgIJAJM4DhRH0vmuMAoGCCqGSM49BAMEMB4xCzAJBgNVBAYT
@@ -105,15 +113,17 @@ spec:
               mountPath: /run/spire/sockets
               readOnly: false
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:

--- a/examples/k8s/postgres/spire-server.yaml
+++ b/examples/k8s/postgres/spire-server.yaml
@@ -75,6 +75,14 @@ data:
         }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
   bootstrap.crt: |
     -----BEGIN CERTIFICATE-----
     MIIBzDCCAVOgAwIBAgIJAJM4DhRH0vmuMAoGCCqGSM49BAMEMB4xCzAJBgNVBAYT
@@ -134,15 +142,17 @@ spec:
               mountPath: /run/k8s-certs/sa.pub
               readOnly: true
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:

--- a/examples/k8s/simple_psat/spire-agent.yaml
+++ b/examples/k8s/simple_psat/spire-agent.yaml
@@ -77,6 +77,14 @@ data:
           }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
   bootstrap.crt: |
     -----BEGIN CERTIFICATE-----
     MIIBzDCCAVOgAwIBAgIJAJM4DhRH0vmuMAoGCCqGSM49BAMEMB4xCzAJBgNVBAYT
@@ -135,15 +143,17 @@ spec:
             - name: spire-token
               mountPath: /var/run/secrets/tokens
           livenessProbe:
-            exec:      
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:
@@ -156,8 +166,8 @@ spec:
             type: DirectoryOrCreate
         - name: spire-token
           projected:
-           sources:
-           - serviceAccountToken:
-              path: spire-agent
-              expirationSeconds: 7200
-              audience: spire-server
+            sources:
+            - serviceAccountToken:
+                path: spire-agent
+                expirationSeconds: 7200
+                audience: spire-server

--- a/examples/k8s/simple_psat/spire-server.yaml
+++ b/examples/k8s/simple_psat/spire-server.yaml
@@ -111,6 +111,14 @@ data:
         }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
   bootstrap.crt: |
     -----BEGIN CERTIFICATE-----
     MIIBzDCCAVOgAwIBAgIJAJM4DhRH0vmuMAoGCCqGSM49BAMEMB4xCzAJBgNVBAYT
@@ -164,15 +172,17 @@ spec:
               mountPath: /run/spire/data
               readOnly: false
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:

--- a/examples/k8s/simple_sat/spire-agent.yaml
+++ b/examples/k8s/simple_sat/spire-agent.yaml
@@ -49,6 +49,14 @@ data:
           }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
   bootstrap.crt: |
     -----BEGIN CERTIFICATE-----
     MIIBzDCCAVOgAwIBAgIJAJM4DhRH0vmuMAoGCCqGSM49BAMEMB4xCzAJBgNVBAYT
@@ -105,15 +113,17 @@ spec:
               mountPath: /run/spire/sockets
               readOnly: false
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:

--- a/examples/k8s/simple_sat/spire-server.yaml
+++ b/examples/k8s/simple_sat/spire-server.yaml
@@ -81,6 +81,14 @@ data:
         }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
   bootstrap.crt: |
     -----BEGIN CERTIFICATE-----
     MIIBzDCCAVOgAwIBAgIJAJM4DhRH0vmuMAoGCCqGSM49BAMEMB4xCzAJBgNVBAYT
@@ -137,15 +145,17 @@ spec:
               mountPath: /run/k8s-certs/sa.pub
               readOnly: true
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:


### PR DESCRIPTION
Signed-off-by: Ryuma Yoshida <ryuma.y1117@gmail.com>

In the [spiffe/spire](https://github.com/spiffe/spire) repository, the healthcheck endpoints is used for livenessProbe and readinessProbe in the kubernetes manifest. So it would be good to use the endpoints in this repository as well.