### PR TITLE
Update Ubuntu to 22.04 on CI runner

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -10,7 +10,7 @@ env:
   CHANGE_MINIKUBE_NONE_USER: true
 jobs:
   test-all:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps: 
       - name: Checkout


### PR DESCRIPTION
Ubuntu 18.04 is deprecated and set to be unsupported April 1, 2023: https://github.com/actions/runner-images/issues/6002