### PR TITLE
Update Go to 1.19.4 on CI runner

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 env:
-  GO_VERSION: 1.16.5
+  GO_VERSION: 1.19.4
   CHANGE_MINIKUBE_NONE_USER: true
 jobs:
   test-all:


### PR DESCRIPTION
Use the latest version of Go.