### PR TITLE
Improve SAT NodeAttestor example

### DIFF
--- a/examples/k8s/simple_sat/README.md
+++ b/examples/k8s/simple_sat/README.md
@@ -31,3 +31,9 @@ Start the agent DaemonSet:
 ```
 $ kubectl apply -f spire-agent.yaml
 ```
+
+## Test
+
+Simply run `./test.sh`, this script will start a cluster using [kind](https://kind.sigs.k8s.io/), deploy spire server and
+agent, and run a simple test to verify the node attestation process using SAT NodeAttestor.
+

--- a/examples/k8s/simple_sat/spire-agent.yaml
+++ b/examples/k8s/simple_sat/spire-agent.yaml
@@ -1,3 +1,4 @@
+# Create a service account for the spire-agent
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,6 +7,7 @@ metadata:
 
 ---
 
+# Create the config map for the spire-agent, which contains the agent configuration file
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -73,6 +75,7 @@ data:
 
 ---
 
+# Create the spire-agent daemonset
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -100,11 +103,11 @@ spec:
           # you prefer that waits for a service to be up. This image is built
           # from https://github.com/lqhl/wait-for-it
           image: gcr.io/spiffe-io/wait-for-it
-          args: ["-t", "30", "spire-server:8081"]
+          args: [ "-t", "30", "spire-server:8081" ]
       containers:
         - name: spire-agent
           image: ghcr.io/spiffe/spire-agent:1.5.1
-          args: ["-config", "/run/spire/config/agent.conf"]
+          args: [ "-config", "/run/spire/config/agent.conf" ]
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config

--- a/examples/k8s/simple_sat/spire-server.yaml
+++ b/examples/k8s/simple_sat/spire-server.yaml
@@ -1,10 +1,12 @@
 apiVersion: v1
+# Create the spire namespace
 kind: Namespace
 metadata:
   name: spire
 
 ---
 
+# Create a service account for the spire-server
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,6 +15,36 @@ metadata:
 
 ---
 
+# Create cluster role allowed to create resource "tokenreviews" in API group "authentication.k8s.io".
+# This is required by the server to authenticate agents using [Token Review API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spire-server
+rules:
+  - apiGroups: [ "authentication.k8s.io" ]
+    resources: [ "tokenreviews" ]
+    verbs: [ "create" ]
+
+---
+
+# Bind the spire-server service account to the role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spire-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: spire-server
+subjects:
+  - kind: ServiceAccount
+    name: spire-server
+    namespace: spire
+
+---
+
+# Create the upstream authority private key
 apiVersion: v1
 kind: Secret
 metadata:
@@ -24,6 +56,7 @@ data:
 
 ---
 
+# Create the config map for the spire-server, which contains the server configuration file
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -56,7 +89,7 @@ data:
         plugin_data {
           clusters = {
             "demo-cluster" = {
-              service_account_key_file = "/run/k8s-certs/sa.pub"
+              use_token_review_api_validation = true
               service_account_allow_list = ["spire:spire-agent"]
             }
           }
@@ -100,6 +133,7 @@ data:
 
 ---
 
+# Create the spire-server statefulset
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -123,7 +157,7 @@ spec:
       containers:
         - name: spire-server
           image: ghcr.io/spiffe/spire-server:1.5.1
-          args: ["-config", "/run/spire/config/server.conf"]
+          args: [ "-config", "/run/spire/config/server.conf" ]
           ports:
             - containerPort: 8081
           volumeMounts:
@@ -136,9 +170,6 @@ spec:
             - name: spire-data
               mountPath: /run/spire/data
               readOnly: false
-            - name: k8s-sa-cert
-              mountPath: /run/k8s-certs/sa.pub
-              readOnly: true
           livenessProbe:
             httpGet:
               path: /live
@@ -160,10 +191,6 @@ spec:
         - name: spire-secrets
           secret:
             secretName: spire-server
-        - name: k8s-sa-cert
-          hostPath:
-            path: /var/lib/minikube/certs/sa.pub
-            type: File
   volumeClaimTemplates:
     - metadata:
         name: spire-data
@@ -177,6 +204,7 @@ spec:
 
 ---
 
+# Create the spire-server service binding to the spire-server statefulset
 apiVersion: v1
 kind: Service
 metadata:

--- a/examples/k8s/simple_sat/test.sh
+++ b/examples/k8s/simple_sat/test.sh
@@ -13,12 +13,17 @@ fail() {
 	exit 1
 }
 
+create-cluster() {
+	kind delete cluster -n demo-cluster > /dev/null
+  kind create cluster -n demo-cluster || fail "Failed to create cluster"
+}
+
 delete-ns() {
 	echo "${bold}Cleaning up...${norm}"
-    kubectl delete --ignore-not-found namespace spire > /dev/null
 }
 
 cleanup() {
+    kind delete cluster -n demo-cluster > /dev/null
     if [ -z "${GOOD}" ]; then
         echo "${yellow}Dumping statefulset/spire-server logs...${norm}"
         kubectl -nspire logs statefulset/spire-server --all-containers
@@ -36,6 +41,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "${bold}Preparing environment...${norm}"
+create-cluster
 delete-ns
 kubectl create namespace spire
 


### PR DESCRIPTION
Use kind for creating the cluster in the test script, and use token review API for the node attestation process.