### PR TITLE
Update spire-agent daemonset to use node IP from downward API (#4147)

### DIFF
--- a/examples/k8s/advanced/spire-chart/templates/agent-configmap.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/agent-configmap.tpl
@@ -32,6 +32,7 @@ data:
           {{- else }}
           skip_kubelet_verification = true
           {{- end }}
+          node_name_env = "MY_NODE_NAME"
         }
       }
     }

--- a/examples/k8s/advanced/spire-chart/templates/agent-daemonset.tpl
+++ b/examples/k8s/advanced/spire-chart/templates/agent-daemonset.tpl
@@ -30,6 +30,11 @@ spec:
         - name: spire-agent
           image: ghcr.io/spiffe/spire-agent:1.6.1
           args: ["-config", "/run/spire/config/agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config

--- a/examples/k8s/eks_sat/spire-agent.yaml
+++ b/examples/k8s/eks_sat/spire-agent.yaml
@@ -65,6 +65,7 @@ data:
 
       WorkloadAttestor "k8s" {
         plugin_data {
+          node_name_env = "MY_NODE_NAME"
         }
       }
 
@@ -129,6 +130,11 @@ spec:
         - name: spire-agent
           image: ghcr.io/spiffe/spire-agent:1.6.1
           args: ["-config", "/run/spire/config/agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config

--- a/examples/k8s/k7e/base_minikube_sat/config/spire-agent.conf
+++ b/examples/k8s/k7e/base_minikube_sat/config/spire-agent.conf
@@ -26,6 +26,7 @@ plugins {
       # Minikube does not have a cert in the cluster CA bundle that
       # can authenticate the kubelet cert, so skip validation.
       skip_kubelet_verification = true
+      node_name_env = "MY_NODE_NAME"
     }
   }
 

--- a/examples/k8s/k7e/base_minikube_sat/spire-agent/spire-agent-deployment.yaml
+++ b/examples/k8s/k7e/base_minikube_sat/spire-agent/spire-agent-deployment.yaml
@@ -31,6 +31,11 @@ spec:
           image: ghcr.io/spiffe/spire-agent:1.6.1
           imagePullPolicy: Always
           args: ["-config", "/run/spire/config/spire-agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config

--- a/examples/k8s/postgres/spire-agent.yaml
+++ b/examples/k8s/postgres/spire-agent.yaml
@@ -41,6 +41,7 @@ data:
           # Minikube does not have a cert in the cluster CA bundle that
           # can authenticate the kubelet cert, so skip validation.
           skip_kubelet_verification = true
+          node_name_env = "MY_NODE_NAME"
         }
       }
 
@@ -105,6 +106,11 @@ spec:
         - name: spire-agent
           image: ghcr.io/spiffe/spire-agent:1.6.1
           args: ["-config", "/run/spire/config/agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config

--- a/examples/k8s/simple_psat/spire-agent.yaml
+++ b/examples/k8s/simple_psat/spire-agent.yaml
@@ -69,6 +69,7 @@ data:
             # Minikube does not have a cert in the cluster CA bundle that
             # can authenticate the kubelet cert, so skip validation.
             skip_kubelet_verification = true
+            node_name_env = "MY_NODE_NAME"
         }
       }
 
@@ -133,6 +134,11 @@ spec:
         - name: spire-agent
           image: ghcr.io/spiffe/spire-agent:1.6.1
           args: ["-config", "/run/spire/config/agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config

--- a/examples/k8s/simple_sat/spire-agent.yaml
+++ b/examples/k8s/simple_sat/spire-agent.yaml
@@ -41,6 +41,7 @@ data:
           # Minikube does not have a cert in the cluster CA bundle that
           # can authenticate the kubelet cert, so skip validation.
           skip_kubelet_verification = true
+          node_name_env = "MY_NODE_NAME"
         }
       }
 
@@ -105,6 +106,11 @@ spec:
         - name: spire-agent
           image: ghcr.io/spiffe/spire-agent:1.6.1
           args: ["-config", "/run/spire/config/agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config


### PR DESCRIPTION
Fixes issue [#4147](https://github.com/spiffe/spire/issues/4147) in the spire repo. The spire-agent daemonsets in the examples defaults to using localhost to reach the kubelet API. This fails in some cases and this PR fixes the issue by retrieving the node IP using the downward API and passing it to the spire-agent daemonset configuration.

The issue is raised in the spire repo but fixes span across spire-examples, spire-tutorials and spire-controller-manager repos under the SPIFFE org.
