### PR TITLE
Repo changes and update package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,10 +85,10 @@ jobs:
           gh release upload "${GITHUB_REF#refs/tags/}" examples/rpms/rpm.pub /tmp/releasepackages/*/*/*.rpm /tmp/releasepackages/*/*/*.deb
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: /tmp/packages
+      #- name: Upload Artifact
+      #  uses: actions/upload-pages-artifact@v3
+      #  with:
+      #    path: /tmp/packages
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/examples/rpms/Dockerfile.repos
+++ b/examples/rpms/Dockerfile.repos
@@ -38,14 +38,22 @@ RUN \
 FROM docker.io/library/debian:stable-slim AS deb-builder
 WORKDIR /tmp
 COPY DEBS /tmp/packages/DEBS
+COPY apt-release.conf /tmp/apt-release.conf
 RUN \
   apt-get update && \
-  apt-get install -y --no-install-recommends dpkg-dev gzip && \
+  apt-get install -y --no-install-recommends dpkg-dev apt-utils gzip && \
   rm -rf /var/lib/apt/lists/* && \
+  mkdir -p /tmp/packages/DEBS/binary-amd64/ && \
   cd /tmp/packages/DEBS/amd64 && \
   dpkg-scanpackages --arch amd64 . | gzip -9c > Packages.gz && \
+  cd .. && \
+  dpkg-scanpackages --arch amd64 amd64/ | gzip -9c > binary-amd64/Packages.gz && \
+  mkdir -p /tmp/packages/DEBS/binary-arm64/ && \
   cd /tmp/packages/DEBS/arm64 && \
-  dpkg-scanpackages --arch arm64 . | gzip -9c > Packages.gz
+  dpkg-scanpackages --arch arm64 . | gzip -9c > Packages.gz && \
+  cd .. && \
+  dpkg-scanpackages --arch arm64 arm64/ | gzip -9c > binary-arm64/Packages.gz && \
+  apt-ftparchive -c /tmp/apt-release.conf release . > Release
 
 FROM docker.io/library/nginx:latest
 RUN rm -rf /usr/share/nginx/html/*

--- a/examples/rpms/apt-release.conf
+++ b/examples/rpms/apt-release.conf
@@ -1,0 +1,9 @@
+APT::FTPArchive::Release {
+  Origin "spire-examples";
+  Label "spire-examples";
+  Suite "stable";
+  Codename "stable";
+  Architectures "amd64 arm64";
+  Components "main";
+  Description "Automated Multi-Arch Repo for spire-examples";
+};

--- a/examples/rpms/spiffe-pve-ek.spec
+++ b/examples/rpms/spiffe-pve-ek.spec
@@ -21,7 +21,7 @@
 
 Summary:    SPIFFE PVE EK Service
 Name:       spiffe-pve-ek
-Version:    1.11.1
+Version:    1.11.3
 Release:    1
 Group:      Applications/Internet
 License:    Apache-2.0

--- a/examples/rpms/spire-agent-nodeattestor-tpmdirect.spec
+++ b/examples/rpms/spire-agent-nodeattestor-tpmdirect.spec
@@ -21,7 +21,7 @@
 
 Summary:    SPIRE Agent Node Attestor TPM Direct
 Name:       spire-agent-nodeattestor-tpmdirect
-Version:    1.11.1
+Version:    1.11.3
 Release:    1
 Group:      Applications/Internet
 License:    Apache-2.0

--- a/examples/rpms/spire-server-nodeattestor-tpmdirect.spec
+++ b/examples/rpms/spire-server-nodeattestor-tpmdirect.spec
@@ -21,7 +21,7 @@
 
 Summary:    SPIRE Server Node Attestor TPM Direct
 Name:       spire-server-nodeattestor-tpmdirect
-Version:    1.11.1
+Version:    1.11.3
 Release:    1
 Group:      Applications/Internet
 License:    Apache-2.0


### PR DESCRIPTION
Dont attach rpms/debs to release anymore, just use the repos. Attempt to make a multiarch deb repo. Bump tpm package version.